### PR TITLE
Add monitoring support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,6 +2,7 @@
 #export RUST_LOG=anonymizer=DEBUG,librdkafka=WARN
 export RUST_LOG=anonymizer=INFO,librdkafka=WARN
 export NUM_CONSUMERS=2
+export SHUTDOWN_TIMEOUT=5
 
 # Kafka
 export KAFKA__TOPIC=http_log
@@ -25,3 +26,5 @@ export CH__MAX_BLOCK_SIZE=4096
 export CH__RATE_LIMIT=65
 export CH__RETRIES=3
 
+# Telemetry
+export TELEMETRY__PROMETHEUS_EXPORTER_PORT=9464

--- a/.envrc
+++ b/.envrc
@@ -28,3 +28,4 @@ export CH__RETRIES=3
 
 # Telemetry
 export TELEMETRY__PROMETHEUS_EXPORTER_PORT=9464
+export TELEMETRY__LOKI_URL="http://localhost:3100"

--- a/anonymizer/Cargo.lock
+++ b/anonymizer/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "anonymizer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "capnp",
@@ -42,7 +42,9 @@ dependencies = [
  "tokio",
  "tokio-graceful-shutdown",
  "tracing",
+ "tracing-loki",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -110,6 +112,12 @@ checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "byteorder"
@@ -208,6 +216,22 @@ dependencies = [
  "toml",
  "yaml-rust",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -352,6 +376,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +531,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +626,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -582,6 +641,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +661,16 @@ checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -609,6 +691,12 @@ dependencies = [
  "libc",
  "windows-sys 0.42.0",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
 
 [[package]]
 name = "isahc"
@@ -651,6 +739,15 @@ name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+
+[[package]]
+name = "js-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "json5"
@@ -716,6 +813,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "loki-api"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1b21fa6bc76e25acb47396ec0a66901c895a42b69de12ae48c68c6ce9172ca2"
+dependencies = [
+ "prost",
+ "prost-types",
 ]
 
 [[package]]
@@ -787,6 +894,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,6 +969,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
+name = "openssl"
+version = "0.10.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,9 +1002,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.79"
+version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5454462c0eced1e97f2ec09036abc8da362e66802f66fd20f86854d9d8cbcbc4"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
  "autocfg",
  "cc",
@@ -1106,6 +1257,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+dependencies = [
+ "bytes",
+ "prost",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,6 +1398,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "retry"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,6 +1545,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "security-framework"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,6 +1609,18 @@ version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
  "itoa",
  "ryu",
  "serde",
@@ -1417,6 +1682,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
+name = "snap"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
+
+[[package]]
 name = "socket2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1738,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -1588,6 +1873,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1598,6 +1904,7 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1667,6 +1974,37 @@ checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "lazy_static",
  "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-loki"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c616d5f020d7e61c504c3458f76188fcc91cfdd67dc6e33533d50779a9d743"
+dependencies = [
+ "loki-api",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "snap",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
  "tracing-core",
 ]
 
@@ -1748,6 +2086,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -1789,6 +2128,82 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "web-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "wepoll-ffi"
@@ -1920,6 +2335,15 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/anonymizer/Cargo.lock
+++ b/anonymizer/Cargo.lock
@@ -23,17 +23,24 @@ dependencies = [
  "clickhouse-format",
  "clickhouse-http-client",
  "config",
+ "derive-new",
  "futures",
+ "hyper",
  "itertools",
  "maplit",
+ "prometheus",
+ "prometheus-hyper",
+ "prometheus-metric-storage",
  "rdkafka",
  "retry",
  "rstest",
  "serde",
  "serde_json",
+ "stream-cancel",
  "thiserror",
  "time",
  "tokio",
+ "tokio-graceful-shutdown",
  "tracing",
  "tracing-subscriber",
 ]
@@ -53,6 +60,17 @@ dependencies = [
  "concurrent-queue",
  "event-listener",
  "futures-core",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -92,6 +110,12 @@ checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -244,6 +268,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +307,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -463,6 +519,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +533,52 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "hyper"
+version = "0.14.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
 ]
 
 [[package]]
@@ -490,6 +598,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -576,6 +694,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +738,29 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "miette"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afd9b301defa984bbdbe112b4763e093ed191750a0d914a78c1106b2d0fe703"
+dependencies = [
+ "miette-derive",
+ "once_cell",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97c2401ab7ac5282ca5c8b518a87635b1a93762b0b90b9990c509888eeccba29"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "mime"
@@ -895,6 +1042,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1de8dacb0873f77e6aefc6d71e044761fcc68060290f5b1089fcdf84626bb69"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "hex",
+ "lazy_static",
+ "rustix",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "parking_lot",
+ "procfs",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
+name = "prometheus-hyper"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18fc98d5705a20b11f8b240c0857167b79852ba469f9faec6df0027e576e676e"
+dependencies = [
+ "hyper",
+ "prometheus",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "prometheus-metric-storage"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3282447ea0b07baa9011e45de96794c5963db0162c1001d2867750715d63ff14"
+dependencies = [
+ "lazy_static",
+ "prometheus",
+ "prometheus-metric-storage-derive",
+]
+
+[[package]]
+name = "prometheus-metric-storage-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239221aa10cd35277c58b8f6509280b2613321760b49584d7a7351a6aacb6963"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
 name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,6 +1279,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,6 +1427,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stream-cancel"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0a9eb2715209fb8cc0d942fcdff45674bfc9f0090a0d897e85a22955ad159b"
+dependencies = [
+ "futures-core",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "strum"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1560,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-graceful-shutdown"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb79512dae3f5a9edea10ab138f785c9076643c5485a4395ba16eedb1923a9f"
+dependencies = [
+ "async-recursion",
+ "async-trait",
+ "futures",
+ "log",
+ "miette",
+ "pin-project-lite",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,6 +1588,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,6 +1608,12 @@ checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -1411,6 +1689,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,6 +1734,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1483,6 +1773,16 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"

--- a/anonymizer/Cargo.toml
+++ b/anonymizer/Cargo.toml
@@ -24,16 +24,23 @@ capnp = "0.15"
 clickhouse-format = "0.2"
 clickhouse-http-client = "0.1"
 config = "0.13"
+derive-new = "0.5"
 futures = "0.3"
+hyper = { version = "0.14", default-features = false, features = ["http1", "server", "runtime"] }
 itertools = "0.10"
 maplit = "1.0"
+prometheus = { version = "0.13", features = ["process"] }
+prometheus-hyper = "0.1"
+prometheus-metric-storage = "0.5"
 retry = "2.0"
 rdkafka = "0.29"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+stream-cancel = "0.8"
 thiserror = "1.0"
 time = { version = "0.3", features = ["serde"] }
 tokio = { version = "1.0", features = ["full"] }
+tokio-graceful-shutdown = "0.12"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/anonymizer/Cargo.toml
+++ b/anonymizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anonymizer"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Martin Matyášek <martin.matyasek@gmail.com>"]
 description = "GDPR-complient Kafka-to-ClickHouse ETL pipeline for HTTP logs"
 repository = "https://github.com/matyama/http-log-anonymizer"
@@ -42,7 +42,9 @@ time = { version = "0.3", features = ["serde"] }
 tokio = { version = "1.0", features = ["full"] }
 tokio-graceful-shutdown = "0.12"
 tracing = "0.1"
+tracing-loki = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+url = { version = "2.3", features=["serde"] }
 
 [build-dependencies]
 capnpc = "0.15"

--- a/anonymizer/Dockerfile
+++ b/anonymizer/Dockerfile
@@ -47,6 +47,7 @@ ENV CH__MAX_BLOCK_SIZE 4096
 ENV CH__RATE_LIMIT 65
 ENV CH__RETRIES 3
 ENV TELEMETRY__PROMETHEUS_EXPORTER_PORT 9464
+ENV TELEMETRY__LOKI_URL http://localhost:3100
 WORKDIR app
 RUN apt-get update -qq \
 	&& apt-get install -qq -y --no-install-recommends \

--- a/anonymizer/Dockerfile
+++ b/anonymizer/Dockerfile
@@ -30,6 +30,7 @@ RUN cargo build --release --bins
 FROM debian:bullseye-slim AS runtime
 ENV RUST_LOG anonymizer=INFO,librdkafka=WARN
 ENV NUM_CONSUMERS 2
+ENV SHUTDOWN_TIMEOUT 5
 ENV KAFKA__TOPIC http_log
 ENV KAFKA__BROKERS localhost:9092
 ENV KAFKA__GROUP_ID anonymizer-group
@@ -45,6 +46,7 @@ ENV CH__CREATE_TABLE true
 ENV CH__MAX_BLOCK_SIZE 4096
 ENV CH__RATE_LIMIT 65
 ENV CH__RETRIES 3
+ENV TELEMETRY__PROMETHEUS_EXPORTER_PORT 9464
 WORKDIR app
 RUN apt-get update -qq \
 	&& apt-get install -qq -y --no-install-recommends \
@@ -57,5 +59,5 @@ RUN apt-get update -qq \
 COPY --from=builder \
 	/app/target/release/anonymizer \
 	/usr/local/bin/
-CMD anonymizer
+CMD ["anonymizer"]
 

--- a/anonymizer/README.md
+++ b/anonymizer/README.md
@@ -209,6 +209,7 @@ Here is a list with the notable dependencies that are essential to the anonymize
  - [Cap'n Proto for Rust](https://github.com/capnproto/capnproto-rust)
  - [`librdkafka` for Rust](https://github.com/fede1024/rust-rdkafka)
  - [ClickHouse HTTP client](https://crates.io/crates/clickhouse-http-client)
+ - [`Hyper`-based exporter of Prometheus metrics](https://crates.io/crates/prometheus-hyper)
 
 And to make the implementation more sane this crate also depends on:
  - [`config`](https://crates.io/crates/config) for env-based configuration
@@ -216,6 +217,9 @@ And to make the implementation more sane this crate also depends on:
    [`anyhow`](https://crates.io/crates/anyhow) for better error handling and propagation
  - [Tokio `tracing`](https://github.com/tokio-rs/tracing) for tracing (and logging) in async
    contexts
+ - [Tokio graceful shutdown](https://crates.io/crates/tokio-graceful-shutdown) for
+   orchestrating the application
+ - [`stream-cancel`](https://crates.io/crates/stream-cancel) for stram interruption
 
 ### Known issues & limitations
  - There could be a better separation of the Kafka message ingestion & application logic of the
@@ -232,12 +236,12 @@ And to make the implementation more sane this crate also depends on:
    insert. Therefore it's not currently possible to send compressed data which would allow us
    to increase the insert block size (`CH__MAX_BLOCK_SIZE`) and lower the data latencies for a
    large input batch accumulated in Kafka (i.e. when last committed offset is quite old).
- - The [`source`](source) code generally does not deal with a _graceful shutdown_ and only
+ - ~~The [`source`](source) code generally does not deal with a _graceful shutdown_ and only
    tries to propagate and log meaningful messages. The reason this is not yet supported is
    because it's no straightforwart how the shutdown should behave. Should it for example wait
    till the next insert block finishes? It could be quite a long time depending on
    `CH__RATE_LIMITa`. Or should it iterrupt the insert? But in that case consumers won't commit
-   offsets to Kafka, which essentially defeats the purpose of a _graceful_ shutdown.
+   offsets to Kafka, which essentially defeats the purpose of a _graceful_ shutdown.~~
  - Sink does not retry block inserts (as it does for the create table query). This is for two
    reasons:
     1. It could singnificantly slow down the processing (inside a critical section) depending
@@ -245,7 +249,7 @@ And to make the implementation more sane this crate also depends on:
     1. It would require a (potentially expensive) complete buffer clone because the underlying
        [`clickhouse_http_client::Client`] takes the ownership of the batch being inserted.
  - Currently there is no mechanism for _backpressure_ from the sink to the Kafka consumers
- - Collecting performace metrics is not yet implemented (although this shouldn't be hard)
+ - ~~Collecting performace metrics is not yet implemented (although this shouldn't be hard)~~
  - Generally way more integration and unit tests would be necessary for this to make it into a
    production-ready state
 

--- a/anonymizer/README.md
+++ b/anonymizer/README.md
@@ -1,4 +1,5 @@
-# `anonymizer:0.1.0`
+# anonymizer
+![Version: 0.2.0](https://img.shields.io/badge/version-0.2.0-blue)
 
 ## Environment
 The application expects certain set of environment variables (described below). A working
@@ -217,6 +218,8 @@ And to make the implementation more sane this crate also depends on:
    [`anyhow`](https://crates.io/crates/anyhow) for better error handling and propagation
  - [Tokio `tracing`](https://github.com/tokio-rs/tracing) for tracing (and logging) in async
    contexts
+ - [`tracking-loki`](https://crates.io/crates/tracing-loki) for publishing `tracing` logs to
+   Grafana Loki
  - [Tokio graceful shutdown](https://crates.io/crates/tokio-graceful-shutdown) for
    orchestrating the application
  - [`stream-cancel`](https://crates.io/crates/stream-cancel) for stram interruption

--- a/anonymizer/README.tpl
+++ b/anonymizer/README.tpl
@@ -1,4 +1,5 @@
-# `{{crate}}:{{version}}`
+# {{crate}}
+![Version: {{version}}](https://img.shields.io/badge/version-{{version}}-blue)
 
 ## Environment
 The application expects certain set of environment variables (described below). A working

--- a/anonymizer/src/config.rs
+++ b/anonymizer/src/config.rs
@@ -53,10 +53,12 @@
 //! environment variables:
 //!  - `TELEMETRY__PROMETHEUS_EXPORTER_PORT` is the port that the metrics server will listen to for
 //!    Prometheus metrics scraping requests
+//!  - `TELEMETRY__LOKI_URL` is the URL of the Grafana Loki instance to publish logs/traces to
 //!
 //! ## Example setup
 //! ```bash
 //! export TELEMETRY__PROMETHEUS_EXPORTER_PORT=9464
+//! export TELEMETRY__LOKI_URL="http://localhost:3100"
 //! ```
 //!
 //! ## Caveat: native binary
@@ -81,6 +83,7 @@
 //! ```
 use anyhow::{anyhow, Result};
 use serde::Deserialize;
+use url::Url;
 
 use crate::error::Error;
 
@@ -110,6 +113,7 @@ pub struct ClickHouseConfig {
 #[derive(Debug, Deserialize)]
 pub struct TelemetryConfig {
     pub prometheus_exporter_port: u16,
+    pub loki_url: Url,
 }
 
 #[inline(always)]

--- a/anonymizer/src/lib.rs
+++ b/anonymizer/src/lib.rs
@@ -174,6 +174,7 @@
 //!  - [Cap'n Proto for Rust](https://github.com/capnproto/capnproto-rust)
 //!  - [`librdkafka` for Rust](https://github.com/fede1024/rust-rdkafka)
 //!  - [ClickHouse HTTP client](https://crates.io/crates/clickhouse-http-client)
+//!  - [`Hyper`-based exporter of Prometheus metrics](https://crates.io/crates/prometheus-hyper)
 //!
 //! And to make the implementation more sane this crate also depends on:
 //!  - [`config`](https://crates.io/crates/config) for env-based configuration
@@ -181,6 +182,9 @@
 //!    [`anyhow`](https://crates.io/crates/anyhow) for better error handling and propagation
 //!  - [Tokio `tracing`](https://github.com/tokio-rs/tracing) for tracing (and logging) in async
 //!    contexts
+//!  - [Tokio graceful shutdown](https://crates.io/crates/tokio-graceful-shutdown) for
+//!    orchestrating the application
+//!  - [`stream-cancel`](https://crates.io/crates/stream-cancel) for stram interruption
 //!
 //! ## Known issues & limitations
 //!  - There could be a better separation of the Kafka message ingestion & application logic of the
@@ -197,12 +201,12 @@
 //!    insert. Therefore it's not currently possible to send compressed data which would allow us
 //!    to increase the insert block size (`CH__MAX_BLOCK_SIZE`) and lower the data latencies for a
 //!    large input batch accumulated in Kafka (i.e. when last committed offset is quite old).
-//!  - The [`source`](source) code generally does not deal with a _graceful shutdown_ and only
+//!  - ~~The [`source`](source) code generally does not deal with a _graceful shutdown_ and only
 //!    tries to propagate and log meaningful messages. The reason this is not yet supported is
 //!    because it's no straightforwart how the shutdown should behave. Should it for example wait
 //!    till the next insert block finishes? It could be quite a long time depending on
 //!    `CH__RATE_LIMITa`. Or should it iterrupt the insert? But in that case consumers won't commit
-//!    offsets to Kafka, which essentially defeats the purpose of a _graceful_ shutdown.
+//!    offsets to Kafka, which essentially defeats the purpose of a _graceful_ shutdown.~~
 //!  - Sink does not retry block inserts (as it does for the create table query). This is for two
 //!    reasons:
 //!     1. It could singnificantly slow down the processing (inside a critical section) depending
@@ -210,7 +214,7 @@
 //!     1. It would require a (potentially expensive) complete buffer clone because the underlying
 //!        [`clickhouse_http_client::Client`] takes the ownership of the batch being inserted.
 //!  - Currently there is no mechanism for _backpressure_ from the sink to the Kafka consumers
-//!  - Collecting performace metrics is not yet implemented (although this shouldn't be hard)
+//!  - ~~Collecting performace metrics is not yet implemented (although this shouldn't be hard)~~
 //!  - Generally way more integration and unit tests would be necessary for this to make it into a
 //!    production-ready state
 //!
@@ -224,6 +228,7 @@ pub mod kafka;
 pub mod limiter;
 pub mod sink;
 pub mod source;
+pub mod telemetry;
 
 /// Anonymize an IP address by replacing the last octet with 'x'.
 ///

--- a/anonymizer/src/lib.rs
+++ b/anonymizer/src/lib.rs
@@ -182,6 +182,8 @@
 //!    [`anyhow`](https://crates.io/crates/anyhow) for better error handling and propagation
 //!  - [Tokio `tracing`](https://github.com/tokio-rs/tracing) for tracing (and logging) in async
 //!    contexts
+//!  - [`tracking-loki`](https://crates.io/crates/tracing-loki) for publishing `tracing` logs to
+//!    Grafana Loki
 //!  - [Tokio graceful shutdown](https://crates.io/crates/tokio-graceful-shutdown) for
 //!    orchestrating the application
 //!  - [`stream-cancel`](https://crates.io/crates/stream-cancel) for stram interruption

--- a/anonymizer/src/main.rs
+++ b/anonymizer/src/main.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
+use maplit::hashmap;
 #[cfg(target_os = "linux")]
 use prometheus::process_collector::ProcessCollector;
 use prometheus::Registry;
@@ -12,9 +13,15 @@ use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use anonymizer::{
-    config::Config, error::Error, http_log::HttpLog, sink::ClickHouseSink, source::KafkaSource,
-    telemetry::MetricsExporter,
+    config::Config,
+    error::Error,
+    http_log::HttpLog,
+    sink::ClickHouseSink,
+    source::KafkaSource,
+    telemetry::{MetricsExporter, TracingExporter},
 };
+
+const APP_NAME: &str = "anonymizer";
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -22,13 +29,25 @@ async fn main() -> Result<()> {
     let cfg = Config::from_env()?;
 
     // setup tracing
+    let (loki_layer, loki_task) = tracing_loki::layer(
+        cfg.telemetry.loki_url,
+        hashmap! {
+            "app".to_owned() => APP_NAME.to_owned(),
+            "replica".to_owned() => "0".to_owned(),
+        },
+        hashmap! {},
+    )?;
+
     tracing_subscriber::registry()
         .with(tracing_subscriber::EnvFilter::new(cfg.rust_log))
         .with(tracing_subscriber::fmt::layer())
+        .with(loki_layer)
         .init();
 
+    let tracing = TracingExporter::spawn(loki_task);
+
     // setup metrics
-    let registry = Registry::new_custom(Some("anonymizer".to_owned()), None)?;
+    let registry = Registry::new_custom(Some(APP_NAME.to_owned()), None)?;
     let storage_registry = StorageRegistry::new(registry.clone());
     let registry = Arc::new(registry);
 
@@ -52,6 +71,7 @@ async fn main() -> Result<()> {
 
     // XXX: ClickHouseSink subsystem with mpsc channel to `KafkaConsumer`s
     Toplevel::new()
+        .start("TracingExporter", |subsys| tracing.run(subsys))
         .start("MetricsExporter", |subsys| exporter.run(subsys))
         .start("KafkaSource", |subsys| source.run(subsys))
         .catch_signals()

--- a/anonymizer/src/main.rs
+++ b/anonymizer/src/main.rs
@@ -1,13 +1,20 @@
 use std::sync::Arc;
+use std::time::Duration;
 
-use anyhow::Result;
-use futures::stream::FuturesUnordered;
-use futures::StreamExt;
+use anyhow::{anyhow, Result};
+#[cfg(target_os = "linux")]
+use prometheus::process_collector::ProcessCollector;
+use prometheus::Registry;
+use prometheus_metric_storage::StorageRegistry;
 use tokio::sync::Mutex;
+use tokio_graceful_shutdown::Toplevel;
 use tracing::info;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-use anonymizer::{config::Config, http_log::HttpLog, sink::ClickHouseSink, source::run_consumer};
+use anonymizer::{
+    config::Config, error::Error, http_log::HttpLog, sink::ClickHouseSink, source::KafkaSource,
+    telemetry::MetricsExporter,
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -20,6 +27,14 @@ async fn main() -> Result<()> {
         .with(tracing_subscriber::fmt::layer())
         .init();
 
+    // setup metrics
+    let registry = Registry::new_custom(Some("anonymizer".to_owned()), None)?;
+    let storage_registry = StorageRegistry::new(registry.clone());
+    let registry = Arc::new(registry);
+
+    #[cfg(target_os = "linux")]
+    storage_registry.register(Box::new(ProcessCollector::for_self()))?;
+
     info!(
         consumers = cfg.num_consumers,
         "starting anonymizer pipeline"
@@ -28,15 +43,19 @@ async fn main() -> Result<()> {
     let topic = cfg.kafka.topic.clone();
 
     // crete a shared clickhouse sink
-    let sink = ClickHouseSink::<HttpLog>::new(topic, cfg.ch).await?;
+    let sink = ClickHouseSink::<HttpLog>::new(topic, cfg.ch, &storage_registry).await?;
     let sink = Arc::new(Mutex::new(sink));
 
-    // spawn a group of Kafka consumers
-    (0..cfg.num_consumers)
-        .map(|i| tokio::spawn(run_consumer(i, cfg.kafka.clone(), sink.clone())))
-        .collect::<FuturesUnordered<_>>()
-        .for_each(|_| async {})
-        .await;
+    // compose subsystems
+    let exporter = MetricsExporter::new(cfg.telemetry.prometheus_exporter_port, registry);
+    let source = KafkaSource::new(cfg.num_consumers, cfg.kafka, sink, storage_registry);
 
-    Ok(())
+    // XXX: ClickHouseSink subsystem with mpsc channel to `KafkaConsumer`s
+    Toplevel::new()
+        .start("MetricsExporter", |subsys| exporter.run(subsys))
+        .start("KafkaSource", |subsys| source.run(subsys))
+        .catch_signals()
+        .handle_shutdown_requests(Duration::from_secs(cfg.shutdown_timeout))
+        .await
+        .map_err(|e| anyhow!(Error::ShutdownError(e)))
 }

--- a/anonymizer/src/telemetry.rs
+++ b/anonymizer/src/telemetry.rs
@@ -1,0 +1,85 @@
+//! Module containing components and utilities for telemetry (metrics, tracing, logging).
+//!
+//! TODO
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use derive_new::new;
+use prometheus::{Gauge, Histogram, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Registry};
+use prometheus_hyper::Server;
+use prometheus_metric_storage::{MetricStorage, StorageRegistry};
+use tokio_graceful_shutdown::SubsystemHandle;
+use tracing::{info, instrument, warn};
+
+use crate::error::Error;
+
+// XXX: split out `OutputMetrics` with `subsystem = "output"`
+/// Prometheus metrics for pipeline monitoring
+#[derive(Debug, Clone, MetricStorage)]
+#[metric(subsystem = "pipeline")]
+pub struct Metrics {
+    /// Total count of consumed Kafka messages by status
+    #[metric(labels("status"))]
+    pub messages_total: IntCounterVec,
+
+    /// Message processing latency in seconds
+    pub message_latency_seconds: Histogram,
+
+    /// Message payload size in bytes
+    pub message_payload_bytes: Gauge,
+
+    /// Time in seconds of issuing single insert to ClickHouse
+    pub output_duration_seconds: Histogram,
+
+    /// Number of insert blocks in the output queue
+    pub output_queued_blocks: IntGauge,
+
+    /// The percentage of the capacity of the next block to insert into ClickHouse which has been
+    /// used by insert entries
+    pub output_insert_block_percent: Gauge,
+
+    /// Number of entries to output in the next insert(s) to ClickHouse
+    ///
+    /// Labels:
+    ///  - `type="buffered"` is the current total number of buffered entries in the output queue
+    ///  - `type="insert"` is the number of entries to insert in current output iteration
+    #[metric(labels("type"))]
+    pub output_entries: IntGaugeVec,
+
+    /// Total count of entries inserted to ClickHouse
+    pub output_inserted_total: IntCounter,
+}
+
+impl Metrics {
+    /// Publicly exposes `Metrics::instance(registry)` with custom [`Error::Metrics`]
+    #[inline]
+    pub fn get_or_create(registry: &StorageRegistry) -> Result<&Self> {
+        Self::instance(registry).map_err(|e| anyhow!(Error::Metrics(e)))
+    }
+}
+
+/// Server exporting Prometheus metrics
+#[derive(new)]
+pub struct MetricsExporter {
+    server_port: u16,
+    registry: Arc<Registry>,
+}
+
+// XXX: or `impl IntoSubsystem` but with `async_trait`
+impl MetricsExporter {
+    #[instrument(name = "exporter", fields(port = self.server_port), skip_all)]
+    pub async fn run(self, subsys: SubsystemHandle) -> Result<()> {
+        info!("starting metrics server");
+        Server::run(
+            self.registry,
+            SocketAddr::from(([0; 4], self.server_port)),
+            async {
+                subsys.on_shutdown_requested().await;
+                warn!("shutting down metrics server");
+            },
+        )
+        .await
+        .map_err(|e| anyhow!(Error::MetricsExporter(e)))
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,19 @@ services:
      - ./grafana/dashboards:/var/lib/grafana/dashboards
     container_name: grafana
     depends_on:
+     - loki
      - prometheus
+
+  loki:
+    image: "grafana/loki:2.6.1"
+    ports:
+      - "3100:3100"
+      - "9093:9093"
+      - "9096:9096"
+    volumes:
+     - ./etc/loki/local-config.yml:/etc/loki/local-config.yml
+    command: "-config.file=/etc/loki/local-config.yaml"
+    container_name: loki
 
   prometheus:
     image: "prom/prometheus:v2.34.0"
@@ -153,8 +165,10 @@ services:
       - CH__RATE_LIMIT
       - CH__RETRIES
       - TELEMETRY__PROMETHEUS_EXPORTER_PORT
+      - TELEMETRY__LOKI_URL=http://loki:3100
     depends_on:
       - broker
       - ch-proxy
+      - loki
     container_name: log-anonymizer
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,28 +129,32 @@ services:
       - broker
     container_name: log-producer
 
-  #anonymizer:
-  #  build: anonymizer
-  #  environment:
-  #    - RUST_LOG
-  #    - NUM_CONSUMERS=1
-  #    - KAFKA__TOPIC
-  #    - KAFKA__BROKERS=PLAINTEXT://broker:29092
-  #    - KAFKA__GROUP_ID
-  #    - KAFKA__RETRIES
-  #    - KAFKA__RETRY_DELAY
-  #    - CH__URL=http://ch-proxy:8124
-  #    - CH__USER
-  #    - CH__PASSWORD
-  #    - CH__DATABASE
-  #    - CH__TCP_KEEPALIVE
-  #    - CH__TARGET_TABLE
-  #    - CH__CREATE_TABLE
-  #    - CH__MAX_BLOCK_SIZE
-  #    - CH__RATE_LIMIT
-  #    - CH__RETRIES
-  #  depends_on:
-  #    - broker
-  #    - ch-proxy
-  #  container_name: log-anonymizer
+  anonymizer:
+    build: anonymizer
+    ports:
+      - "${TELEMETRY__PROMETHEUS_EXPORTER_PORT}:${TELEMETRY__PROMETHEUS_EXPORTER_PORT}"
+    environment:
+      - RUST_LOG
+      - NUM_CONSUMERS=1
+      - SHUTDOWN_TIMEOUT
+      - KAFKA__TOPIC
+      - KAFKA__BROKERS=PLAINTEXT://broker:29092
+      - KAFKA__GROUP_ID
+      - KAFKA__RETRIES
+      - KAFKA__RETRY_DELAY
+      - CH__URL=http://ch-proxy:8124
+      - CH__USER
+      - CH__PASSWORD
+      - CH__DATABASE
+      - CH__TCP_KEEPALIVE
+      - CH__TARGET_TABLE
+      - CH__CREATE_TABLE
+      - CH__MAX_BLOCK_SIZE
+      - CH__RATE_LIMIT
+      - CH__RETRIES
+      - TELEMETRY__PROMETHEUS_EXPORTER_PORT
+    depends_on:
+      - broker
+      - ch-proxy
+    container_name: log-anonymizer
 

--- a/etc/loki/local-config.yml
+++ b/etc/loki/local-config.yml
@@ -1,0 +1,41 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+analytics:
+  reporting_enabled: false
+

--- a/etc/prometheus/prometheus.yml
+++ b/etc/prometheus/prometheus.yml
@@ -28,7 +28,13 @@ scrape_configs:
     static_configs:
     - targets: ['jmx-kafka:5556']
 
+  - job_name: 'loki'
+
+    static_configs:
+      - targets: ['loki:3100']
+
   - job_name: 'anonymizer'
 
     static_configs:
       - targets: ['log-anonymizer:9464']
+

--- a/etc/prometheus/prometheus.yml
+++ b/etc/prometheus/prometheus.yml
@@ -27,3 +27,8 @@ scrape_configs:
 
     static_configs:
     - targets: ['jmx-kafka:5556']
+
+  - job_name: 'anonymizer'
+
+    static_configs:
+      - targets: ['log-anonymizer:9464']

--- a/grafana/dashboards/grafana_dashboard_anonymizer_performance.json
+++ b/grafana/dashboards/grafana_dashboard_anonymizer_performance.json
@@ -1,0 +1,820 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "iteration": 1672232041677,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 17,
+      "panels": [],
+      "repeat": "instance",
+      "title": "HTTP Log processing: $instance",
+      "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.4.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "rate(anonymizer_pipeline_message_latency_seconds_sum{instance=~\"$instance\"}[5m])\n/\nrate(anonymizer_pipeline_message_latency_seconds_count{instance=~\"$instance\"}[5m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}} / Mean",
+          "refId": "A",
+          "step": 10
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, rate(anonymizer_pipeline_message_latency_seconds_bucket{instance=~\"$instance\"}[5m]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}} / 99thPercentile",
+          "refId": "B",
+          "step": 10
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "histogram_quantile(0.75, rate(anonymizer_pipeline_message_latency_seconds_bucket{instance=~\"$instance\"}[5m]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}} / 75thPercentile",
+          "refId": "C",
+          "step": 10
+        }
+      ],
+      "title": "Message Processing Latency",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 1
+      },
+      "id": 12,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.4.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "anonymizer_pipeline_messages_total{instance=~\"$instance\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{status}}",
+          "metric": "",
+          "refId": "A",
+          "step": 60
+        }
+      ],
+      "title": "Messages Total",
+      "type": "stat"
+    },
+    {
+      "description": "Average ingested and processed message payload size in bytes over a minute",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "rgba(245, 54, 54, 0.9)",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 0.3
+              },
+              {
+                "color": "rgba(50, 172, 45, 0.97)",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 1
+      },
+      "id": 15,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "8.4.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "avg_over_time(anonymizer_pipeline_message_payload_bytes{instance=~\"$instance\"}[1m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}}",
+          "refId": "A",
+          "step": 60
+        }
+      ],
+      "title": "Processed bytes/m",
+      "type": "gauge"
+    },
+    {
+      "description": "Total count of entries inserted to ClickHouse",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 15,
+        "y": 1
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.4.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "anonymizer_pipeline_output_inserted_total{instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Inserted Total",
+      "type": "stat"
+    },
+    {
+      "description": "Number of entries to output in the next insert(s) to ClickHouse",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 6,
+        "x": 9,
+        "y": 5
+      },
+      "id": 21,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.4.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "anonymizer_pipeline_output_entries{instance=~\"$instance\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{type}}",
+          "metric": "",
+          "refId": "A",
+          "step": 60
+        }
+      ],
+      "title": "Output Entries",
+      "type": "timeseries"
+    },
+    {
+      "description": "The percentage of the capacity of the next block to insert into ClickHouse which has been used by insert entries",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 25
+              },
+              {
+                "color": "orange",
+                "value": 75
+              },
+              {
+                "color": "red",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 15,
+        "y": 5
+      },
+      "id": 23,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "8.4.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "anonymizer_pipeline_output_insert_block_percent{instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Output Insert Block Occupation",
+      "type": "gauge"
+    },
+    {
+      "description": "Time in seconds of issuing single insert to ClickHouse",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 0,
+        "y": 9
+      },
+      "id": 20,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.4.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "rate(anonymizer_pipeline_output_duration_seconds_sum{instance=~\"$instance\"}[5m])\n/\nrate(anonymizer_pipeline_output_duration_seconds_count{instance=~\"$instance\"}[5m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}} / Mean",
+          "refId": "A",
+          "step": 10
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "histogram_quantile(0.99, rate(anonymizer_pipeline_output_duration_seconds_bucket{instance=~\"$instance\"}[5m]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}} / 99thPercentile",
+          "refId": "B",
+          "step": 10
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "histogram_quantile(0.75, rate(anonymizer_pipeline_output_duration_seconds_bucket{instance=~\"$instance\"}[5m]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}} / 75thPercentile",
+          "refId": "C",
+          "step": 10
+        }
+      ],
+      "title": "Output Time",
+      "type": "timeseries"
+    },
+    {
+      "description": "Number of insert blocks in the output queue",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 15,
+        "y": 10
+      },
+      "id": 9,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "8.4.5",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "anonymizer_pipeline_output_queued_blocks{instance=~\"$instance\"}",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{instance}}",
+          "metric": "",
+          "refId": "A",
+          "step": 60
+        }
+      ],
+      "title": "Queued Insert Blocks",
+      "type": "gauge"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 35,
+  "style": "dark",
+  "tags": [
+    "troubleshoot",
+    "anonymizer"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "PBFA97CFB590B2093"
+        },
+        "definition": "label_values(anonymizer_pipeline_messages_total, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Anonymizer Host",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(anonymizer_pipeline_messages_total, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Anonymizer / Performance",
+  "uid": "bSpBj5tVk",
+  "version": 1,
+  "weekStart": ""
+}

--- a/grafana/dashboards/grafana_dashboard_anonymizer_performance.json
+++ b/grafana/dashboards/grafana_dashboard_anonymizer_performance.json
@@ -21,7 +21,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "iteration": 1672232041677,
+  "iteration": 1672430303824,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -88,7 +88,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 9,
         "x": 0,
         "y": 1
@@ -187,7 +187,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 3,
         "x": 9,
         "y": 1
@@ -266,12 +266,12 @@
               }
             ]
           },
-          "unit": "decbytes"
+          "unit": "Bps"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 3,
         "x": 12,
         "y": 1
@@ -308,7 +308,7 @@
           "step": 60
         }
       ],
-      "title": "Processed bytes/m",
+      "title": "Processed bytes",
       "type": "gauge"
     },
     {
@@ -332,7 +332,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
+        "h": 3,
         "w": 3,
         "x": 15,
         "y": 1
@@ -368,6 +368,87 @@
       ],
       "title": "Inserted Total",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-RdYlGr"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 27,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "orientation": "vertical",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 90,
+        "xTickLabelSpacing": 0
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "expr": "sum(count_over_time({app=\"anonymizer\"}[$__interval])) by (level)",
+          "legendFormat": "{{level}}",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Log count per level",
+      "type": "barchart"
     },
     {
       "description": "Number of entries to output in the next insert(s) to ClickHouse",
@@ -429,10 +510,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 12,
+        "h": 9,
         "w": 6,
         "x": 9,
-        "y": 5
+        "y": 4
       },
       "id": 21,
       "links": [],
@@ -506,7 +587,7 @@
         "h": 5,
         "w": 3,
         "x": 15,
-        "y": 5
+        "y": 4
       },
       "id": 23,
       "options": {
@@ -588,10 +669,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 9,
         "x": 0,
-        "y": 9
+        "y": 7
       },
       "id": 20,
       "links": [],
@@ -699,7 +780,7 @@
         "h": 4,
         "w": 3,
         "x": 15,
-        "y": 10
+        "y": 9
       },
       "id": 9,
       "links": [],
@@ -736,6 +817,42 @@
       ],
       "title": "Queued Insert Blocks",
       "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "id": 25,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "expr": "{app=\"anonymizer\"} | json",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs",
+      "type": "logs"
     }
   ],
   "refresh": "5s",

--- a/grafana/provisioning/datasources/datasource.yaml
+++ b/grafana/provisioning/datasources/datasource.yaml
@@ -5,6 +5,8 @@ apiVersion: 1
 deleteDatasources:
   - name: Prometheus
     orgId: 1
+  - name: Loki
+    orgId: 1
 
 # list of datasources to insert/update depending
 # what's available in the database
@@ -48,3 +50,21 @@ datasources:
   version: 1
   # <bool> allow users to edit datasources from the UI.
   editable: true
+
+- name: Loki
+  type: loki
+  access: proxy
+  orgId: 1
+  url: http://loki:3100
+  password:
+  user:
+  database:
+  basicAuth:
+  basicAuthUser:
+  basicAuthPassword:
+  withCredentials:
+  jsonData:
+    maxLines: 1000
+  version: 1
+  editable: true
+


### PR DESCRIPTION
This PR integrates the `anonymizer` pipeline with __Prometheus__ and __Loki__, and adds a _monitoring dashboard_ to __Grafana__.

### Overview
Metrics use the `prometheus` crate and are defined in structure `telemetry::Metrics`. For the Prometheus integration, there is new component `MetricsExporter` which exposes a `/metrics` endpoint on port `TELEMETRY__PROMETHEUS_EXPORTER_PORT` (see `prometheus_hyper` crate).

_Grafana Loki_ is set up as new docker compose service with custom configuration `.etc/loki/local-config.yml` and its metrics are integrated to Prometheus. The application uses the `tracing-loki` crate to set up new tracing layer and spawn a background task which publishes `tracing` output as logs to the Loki service. There is a new environment variable `TELEMETRY__LOKI_URL` which specifies the URL of the Loki instance.

Grafana newly contains a _Anonymizer / Performance_ dashboard with application monitoring based on all the application metrics collected by Prometheus and logs by Loki.

### Fixed issues:
 - Application has been restructured to a system of components using the `tokio-graceful-shutdown` crate and now is able to react to errors and interrupt signals, and gracefully terminate.

### Known issues & limitations:
 - When running the application as a native binary (e.g. `cargo run`), the `MetricsExporter` binds to the host network. This means that the Prometheus instance running in docker by default does not have access to it.

### Notes
Note that the `log-anonymizer` service is now enabled by default in the `docker-compose.yml`.