### PR TITLE
Generalize `KafkaSource` over application data and logic

### DIFF
--- a/anonymizer/Cargo.lock
+++ b/anonymizer/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "anonymizer"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "capnp",

--- a/anonymizer/Cargo.toml
+++ b/anonymizer/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-capnp = "0.15"
+capnp = { version = "0.15", features = ["unaligned"] }
 clickhouse-format = "0.2"
 clickhouse-http-client = "0.1"
 config = "0.13"

--- a/anonymizer/Cargo.toml
+++ b/anonymizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anonymizer"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Martin Matyášek <martin.matyasek@gmail.com>"]
 description = "GDPR-complient Kafka-to-ClickHouse ETL pipeline for HTTP logs"
 repository = "https://github.com/matyama/http-log-anonymizer"

--- a/anonymizer/README.md
+++ b/anonymizer/README.md
@@ -1,5 +1,5 @@
 # anonymizer
-![Version: 0.3.0](https://img.shields.io/badge/version-0.3.0-blue)
+![Version: 0.4.0](https://img.shields.io/badge/version-0.4.0-blue)
 
 ## Environment
 The application expects certain set of environment variables (described below). A working
@@ -225,8 +225,8 @@ And to make the implementation more sane this crate also depends on:
  - [`stream-cancel`](https://crates.io/crates/stream-cancel) for stram interruption
 
 ### Known issues & limitations
- - There could be a better separation of the Kafka message ingestion & application logic of the
-   anonymizer pipeline
+ - ~~There could be a better separation of the Kafka message ingestion & application logic of
+   the anonymizer pipeline~~ _[addressed in `v0.4.0`]_
  - ~~The sink is currently shared with a standard [`Arc`](std::sync::Arc) and
    [`Mutex`](tokio::sync::Mutex) combination, but it would be interesting to investigate some
    _lock-free_ approaches or other design options how to overcome the congestion point

--- a/anonymizer/src/http_log.rs
+++ b/anonymizer/src/http_log.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 use time::OffsetDateTime;
 
 use crate::sink::{CompactJsonRow, SinkRow};
+use crate::{anonymize_ip, Anonymize};
 
 pub mod model {
     include!(concat!(env!("OUT_DIR"), "/http_log_capnp.rs"));
@@ -25,6 +26,13 @@ pub struct HttpLog {
     pub method: String,
     pub remote_addr: String,
     pub url: String,
+}
+
+impl Anonymize for HttpLog {
+    fn anonymize(mut self) -> Self {
+        self.remote_addr = anonymize_ip(self.remote_addr);
+        self
+    }
 }
 
 impl TryFrom<OwnedMessage> for HttpLog {

--- a/anonymizer/src/lib.rs
+++ b/anonymizer/src/lib.rs
@@ -189,8 +189,8 @@
 //!  - [`stream-cancel`](https://crates.io/crates/stream-cancel) for stram interruption
 //!
 //! ## Known issues & limitations
-//!  - There could be a better separation of the Kafka message ingestion & application logic of the
-//!    anonymizer pipeline
+//!  - ~~There could be a better separation of the Kafka message ingestion & application logic of
+//!    the anonymizer pipeline~~ _[addressed in `v0.4.0`]_
 //!  - ~~The sink is currently shared with a standard [`Arc`](std::sync::Arc) and
 //!    [`Mutex`](tokio::sync::Mutex) combination, but it would be interesting to investigate some
 //!    _lock-free_ approaches or other design options how to overcome the congestion point

--- a/anonymizer/src/lib.rs
+++ b/anonymizer/src/lib.rs
@@ -235,6 +235,12 @@ pub mod sink;
 pub mod source;
 pub mod telemetry;
 
+/// Typeclass representing types that can be anonymized (transformed).
+pub trait Anonymize {
+    /// Turn self into a new value of the same type but with confidential information removed.
+    fn anonymize(self) -> Self;
+}
+
 /// Anonymize an IP address by replacing the last octet with 'x'.
 ///
 /// Any non-IP input is returned unchanged.


### PR DESCRIPTION
### Overview
- Decomposes `run_consumer` from `KafkaConsumer` into few logical parts extracts the communication layer between consumers and the `ClickHouseSink` into dedicated component `SinkConnector`.
- Introduces a new trait `Anonymize` representing types that the pipeline accepts and transforms and adds an instance of this typeclass for the `HttpLog`.
- Abstracts `KafkaConsumer` and consequently `KafkaSource` over the type of data it parses from a Kafka message and anonymizes.