### PR TITLE
Trim down Cargo and Docker dependencies

### DIFF
--- a/anonymizer/.dockerignore
+++ b/anonymizer/.dockerignore
@@ -3,7 +3,7 @@
 .envrc
 
 # Docs and other irrelevant sources
-README.md
+README.*
 LICENSE
 
 # Git
@@ -14,4 +14,10 @@ LICENSE
 .dockerignore
 Dockerfile
 docker-compose.yml
+
+# Build artifacts
+target/
+
+# IDEs
+.vscode/
 

--- a/anonymizer/Cargo.lock
+++ b/anonymizer/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "anonymizer"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "capnp",

--- a/anonymizer/Cargo.lock
+++ b/anonymizer/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
  "clickhouse-http-client",
  "config",
  "derive-new",
- "futures",
+ "futures-util",
  "hyper",
  "itertools",
  "maplit",
@@ -1338,12 +1338,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
 name = "proc-macro-crate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,36 +1470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
 name = "rdkafka"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1530,7 +1494,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d222a401698c7f2010e3967353eae566d9934dcda49c29910da922414ab4e3f4"
 dependencies = [
  "libc",
- "libz-sys",
  "num_enum",
  "pkg-config",
 ]
@@ -1619,9 +1582,6 @@ name = "retry"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9166d72162de3575f950507683fac47e30f6f2c3836b71b7fbc61aa517c9c5f4"
-dependencies = [
- "rand",
-]
 
 [[package]]
 name = "ron"
@@ -2057,7 +2017,6 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/anonymizer/Cargo.toml
+++ b/anonymizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anonymizer"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Martin Matyášek <martin.matyasek@gmail.com>"]
 description = "GDPR-complient Kafka-to-ClickHouse ETL pipeline for HTTP logs"
 repository = "https://github.com/matyama/http-log-anonymizer"
@@ -16,9 +16,19 @@ path = "src/lib.rs"
 name = "anonymizer"
 path = "src/main.rs"
 
-# TODO: rdkafka - add `features = ["dynamic-linking"] ` for `librdkafka` in Docker build
-#  - Docker issue: installed version of librdkafka is 1.6.0, required rdkafka >= 1.9.2
-# XXX: hyper it there only for the error type, unfortunately `prometheus-hyper` does not export it
+# allow for maximum size reduction optimizations
+[profile.release-min]
+inherits = "release"
+strip = true
+lto = true
+codegen-units = 1
+
+# NOTE: `rdkafka` should not enable the `dynamic-linking` feature
+#  - This is because we want a fully static binary for the Docker build which
+#    cross-compiles to musl target and run the binary in an Alpine image
+#  - https://github.com/LukeMathWalker/cargo-chef#running-the-binary-in-alpine
+
+# NOTE: `prometheus-hyper` does not export `hyper` itself, hence the dependency
 
 [dependencies]
 anyhow = "1.0"

--- a/anonymizer/Cargo.toml
+++ b/anonymizer/Cargo.toml
@@ -17,6 +17,8 @@ name = "anonymizer"
 path = "src/main.rs"
 
 # TODO: rdkafka - add `features = ["dynamic-linking"] ` for `librdkafka` in Docker build
+#  - Docker issue: installed version of librdkafka is 1.6.0, required rdkafka >= 1.9.2
+# XXX: hyper it there only for the error type, unfortunately `prometheus-hyper` does not export it
 
 [dependencies]
 anyhow = "1.0"
@@ -25,22 +27,22 @@ clickhouse-format = "0.2"
 clickhouse-http-client = "0.1"
 config = "0.13"
 derive-new = "0.5"
-futures = "0.3"
-hyper = { version = "0.14", default-features = false, features = ["http1", "server", "runtime"] }
+futures-util = "0.3"
+hyper = { version = "0.14", default-features = false }
 itertools = "0.10"
 maplit = "1.0"
 prometheus = { version = "0.13", features = ["process"] }
 prometheus-hyper = "0.1"
 prometheus-metric-storage = "0.5"
-retry = "2.0"
-rdkafka = "0.29"
+retry = { version = "2.0", default-features = false }
+rdkafka = { version = "0.29", default-features = false, features = ["tokio"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "2.1"
 stream-cancel = "0.8"
 thiserror = "1.0"
 time = { version = "0.3", features = ["serde"] }
-tokio = { version = "1.0", features = ["full"] }
+tokio = { version = "1.0", default-features = false, features = ["rt-multi-thread", "time", "macros", "sync"] }
 tokio-graceful-shutdown = "0.12"
 tracing = "0.1"
 tracing-loki = "0.2"

--- a/anonymizer/Dockerfile
+++ b/anonymizer/Dockerfile
@@ -4,9 +4,9 @@ RUN apt-get update -qq \
 	&& apt-get install -qq -y --no-install-recommends \
 		capnproto \
 		libcapnp-dev \
-        build-essential \
-        openssl \
-        libssl-dev \
+    build-essential \
+    openssl \
+    libssl-dev \
 		pkg-config \
 		librdkafka1 \
 		librdkafka-dev \
@@ -54,11 +54,9 @@ ENV TELEMETRY__LOKI_URL http://localhost:3100
 WORKDIR app
 RUN apt-get update -qq \
 	&& apt-get install -qq -y --no-install-recommends \
-		capnproto \
-		libcapnp-dev \
 		librdkafka1 \
 		librdkafka-dev \
-        libc6 \
+    libc6 \
 	&& rm -rf /var/lib/apt/lists/*
 COPY --from=builder \
 	/app/target/release/anonymizer \

--- a/anonymizer/Dockerfile
+++ b/anonymizer/Dockerfile
@@ -1,18 +1,15 @@
-ARG RUST_TAG=1.66-slim
-FROM rust:${RUST_TAG} AS chef 
+ARG RUST_TAG=1.66.0-stable
+FROM clux/muslrust:${RUST_TAG} AS chef 
 RUN apt-get update -qq \
 	&& apt-get install -qq -y --no-install-recommends \
 		capnproto \
 		libcapnp-dev \
-    build-essential \
-    openssl \
-    libssl-dev \
-		pkg-config \
-		librdkafka1 \
 		librdkafka-dev \
+		upx-ucl \
 	&& rm -rf /var/lib/apt/lists/*
+USER root
 RUN cargo install cargo-chef 
-WORKDIR app
+WORKDIR /app
 
 FROM chef AS planner
 COPY . .
@@ -21,13 +18,23 @@ RUN cargo chef prepare  --recipe-path recipe.json
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
 # Build and cache dependencies
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook \
+	--profile release-min \
+	--target x86_64-unknown-linux-musl \
+	--recipe-path recipe.json
 # Build application
 COPY . .
-RUN cargo build --release --bins
+RUN cargo build \
+	--profile release-min \
+	--target x86_64-unknown-linux-musl \
+	--bin anonymizer
+# Compress binary
+RUN upx --best --lzma \
+	/app/target/x86_64-unknown-linux-musl/release-min/anonymizer
 
 # Build runtime image without the Rust toolchain and additional dependencies
-FROM debian:bullseye-slim AS runtime
+FROM alpine:3.17 AS runtime
+RUN addgroup -S anonymizer && adduser -S anonymizer -G anonymizer
 ENV RUST_LOG anonymizer=INFO,librdkafka=WARN
 ENV NUM_CONSUMERS 2
 ENV SHUTDOWN_TIMEOUT 5
@@ -51,15 +58,9 @@ ENV CH__RATE_LIMIT 65
 ENV CH__RETRIES 3
 ENV TELEMETRY__PROMETHEUS_EXPORTER_PORT 9464
 ENV TELEMETRY__LOKI_URL http://localhost:3100
-WORKDIR app
-RUN apt-get update -qq \
-	&& apt-get install -qq -y --no-install-recommends \
-		librdkafka1 \
-		librdkafka-dev \
-    libc6 \
-	&& rm -rf /var/lib/apt/lists/*
 COPY --from=builder \
-	/app/target/release/anonymizer \
+	/app/target/x86_64-unknown-linux-musl/release-min/anonymizer \
 	/usr/local/bin/
+USER anonymizer
 CMD ["anonymizer"]
 

--- a/anonymizer/README.md
+++ b/anonymizer/README.md
@@ -1,5 +1,5 @@
 # anonymizer
-![Version: 0.4.0](https://img.shields.io/badge/version-0.4.0-blue)
+![Version: 0.4.1](https://img.shields.io/badge/version-0.4.1-blue)
 
 ## Environment
 The application expects certain set of environment variables (described below). A working

--- a/anonymizer/src/source.rs
+++ b/anonymizer/src/source.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use anyhow::bail;
 use anyhow::{anyhow, Result};
 use derive_new::new;
-use futures::TryStreamExt;
+use futures_util::TryStreamExt;
 use prometheus_metric_storage::StorageRegistry;
 use rdkafka::consumer::CommitMode;
 use rdkafka::consumer::Consumer;


### PR DESCRIPTION
### Overview
This commit updates the list of dependencies in `Cargo.toml` and the runtime image specified in `Dockerfile` in the effort to reduce the size of the application binary and the Docker image.

#### Dependency changes
 - `Cargo.toml` now defines only relevant features for each dependency and disables defaults if possible
 - `capnproto` dependencies have been removed from `Dockerfile` (the final runtime image), because they are relevant only for the compilation stage
 - `.dockerignore` has been updated to exclude some irrelevant files from the Docker image

#### Binary and Docker changes
The changes/additions are two-fold:
 1. There is a new build profile called `release-min` which in addition to `release` minimizes the binary in terms of its size:
     ```toml
     [profile.release-min]
     inherits = "release"
     strip = true
     lto = true
     codegen-units = 1
     ``` 
 1. The runtime Docker image is now based on `alpine:3.17`.

Ad `Dockerfile` changes, there are few more notable updates:
 - Because of the switch to Alpine, the build stage is now based on the `clux/muslrust` base image.
 - The above change additionally constrains the build to produce a _fully static binary_. This means that we resign on using `dynamic-linking` for `rdkafka`.
 - There is another build stage step of compressing the final binary with `upx` (~70% compression).

### Results
 - Original image size: ~135 MB
 - Reduced image size: 11 MB
 - Binary size: 3.7 MB (compressed) or 11 MB (just from `--profile release-min`)

### Notes
Note that this PR also bumps the crate version to `0.4.1`. Strictly speaking the changes in dependencies might be considered breaking changes resulting in the minor (effectively major) version increment, but since the application logic remains unaffected, only the patch version was changed.